### PR TITLE
Add Makefile target and config file for module installation

### DIFF
--- a/thinklmi-kernel/Makefile
+++ b/thinklmi-kernel/Makefile
@@ -1,10 +1,22 @@
 obj-m := think-lmi.o
 
-KDIR  := /lib/modules/$(shell uname -r)/build
-PWD   := $(shell pwd)
+KERNELRELEASE := $(shell uname -r)
+KDIR := /lib/modules/$(KERNELRELEASE)/build
+PWD := $(shell pwd)
+INSTALL	:= install
+MODLOADDIR := /etc/modules-load.d
+MODLOADCONF := $(MODLOADDIR)/think-lmi.conf
 
 default:
 	$(MAKE) -C $(KDIR) M=$(PWD) modules
 
 clean:
 	$(MAKE) -C $(KDIR) M=$(PWD) clean
+
+modules_install:
+	$(INSTALL) -m 644 think-lmi.ko /lib/modules/$(KERNELRELEASE)/extra/
+
+install: modules_install
+	$(INSTALL) -m 644 think-lmi.conf $(MODLOADDIR)
+	depmod
+	modprobe think-lmi

--- a/thinklmi-kernel/think-lmi.conf
+++ b/thinklmi-kernel/think-lmi.conf
@@ -1,0 +1,6 @@
+# Config file to auto-load the think-lmi kernel module.
+#
+# This file should be installed to "/etc/modules-load.d/". It tries to load
+# think-lmi module located in: "/lib/modules/$(uname -r)/extra/" with system
+# startup.
+think-lmi


### PR DESCRIPTION
This commit added essential Makefile targets to install driver module and config file for auto-load with system startup.

This helps user install and enable the think-lmi module by a simple command:

``` bash
$ sudo make install
```