### PR TITLE
Fix for change setting failed with special char '\' using strreplace

### DIFF
--- a/thinklmi-kernel/think-lmi.c
+++ b/thinklmi-kernel/think-lmi.c
@@ -394,6 +394,7 @@ static int think_lmi_get_bios_selections(const char *item, char **value)
 
 static int think_lmi_set_bios_settings(const char *settings)
 {
+	strreplace(settings,'\\','/');
 	return think_lmi_simple_call(LENOVO_SET_BIOS_SETTINGS_GUID, settings);
 }
 


### PR DESCRIPTION
Fix for change setting failed with special char '\'
using strreplace to change '\' to '/'