### PR TITLE
Fix building of kernel module for older kernels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # thinklmi
 Utility for easy access to BIOS WMI settings
 
-Note: ThinkLMI is now integrated upstream into the Linux kernel (5.17 onwards) using the firmware-attributes class.
+**WARNING: THIS DRIVER SHOULD NOT BE USED FOR KERNELS 5.17 AND NEWER**
+Please use the upstream firmware-attributes class driver if available.
 As long as it is included by your distro you can do
   sudo modprobe think-lmi
 and then access the WMI attributes under /sys/class/firmware-attributes/thinklmi
 
 The kernel documentation has details on how to use this: https://github.com/torvalds/linux/blob/master/Documentation/ABI/testing/sysfs-class-firmware-attributes
 
-The driver and matching user-space utility here should only be used if the kernel driver is not available. Note that thinklmi-user does not currently work with the upstream kernel driver as they use different interfaces (ioctl vs sysfs)
+Ths driver and matching user-space utility here should only be used if the kernel driver is not available. Note that thinklmi-user does not currently work with the upstream kernel driver as they use different interfaces (ioctl vs sysfs)

--- a/thinklmi-kernel/README.md
+++ b/thinklmi-kernel/README.md
@@ -1,5 +1,9 @@
 # think-lmi
 
+**WARNING: THIS DRIVER SHOULD NOT BE USED FOR KERNELS 5.17 AND NEWER**
+Please use the upstream firmware-attributes class driver if available.
+https://github.com/torvalds/linux/blob/master/Documentation/ABI/testing/sysfs-class-firmware-attributes
+
 Linux Driver for Think WMI interface.
 This dirver allows you to control many BIOS settings from Linux via sysfs
 entrypoints or ioctls.

--- a/thinklmi-kernel/think-lmi.c
+++ b/thinklmi-kernel/think-lmi.c
@@ -806,7 +806,11 @@ static void think_lmi_chardev_initialize(struct think_lmi *think)
 		return;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0))
 	tlmi_class = class_create("char");
+#else
+	tlmi_class = class_create(THIS_MODULE, "char");
+#endif
 	if (IS_ERR(tlmi_class)) {
 		pr_warn("tlmi: char dev class creation failed\n");
 		cdev_del(&think->c_dev);


### PR DESCRIPTION
This driver is intended for use on older kernels, but commit 8471176 breaks this by updating the class_create API to be compatible with newer kernels.
Add in kernel version check - but it comes with the caveat that this driver should not be used on kernels newer than 5.17. I've left it able to build in case there is some strange cornercase I don't know of where the firmware-attributes class can't be used.

Highlighted the requirements more explicitely in the README's to try and avoid furthre confusion.

Fixes: 8471176 - Advantest issue fix